### PR TITLE
Py39

### DIFF
--- a/notes.rst
+++ b/notes.rst
@@ -1,0 +1,33 @@
+Upgrading twol package from Python 3.6 to 3.9
+=============================================
+
+1) Downloaded a recent twol-dev package which is said to be compatible with
+   Python 3.9:
+   
+     hfst_dev-3.15.0.10b0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl
+   
+   from PyPI: https://pypi.org/project/hfst-dev/3.15.0.10b0/#files
+
+2) Installed it locally:
+
+   $ pip3 install --upgrade --user --force ~/tmp/hfst_dev-3.15.0.10b0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl
+
+3) Installed a newer version of TatSu, i.e. 5.7 which is said to be compatible
+   with Python 3.8 and up.  (The latest version goes with 3.10 and up):
+
+     pip3 install --user TatSu==5.7
+
+4) Located all "import hfst" (by egrep 'import .*hfst' *.py) and changed 
+   them into "import hfst_dev as hfst".
+
+5) Located all calls "HfstBasicTransducer()" and converted them into
+   "HfstIterableTransducer()" as the newer HFST requires.
+
+6) Corrected the syntax of twolcsyntax.ebnf so that it handles multiple context
+   parts in twol rules.  (Removed also some constructs that do not belong
+   to the twol algebra, e.g. ".u", ".l" and ".o.".) 
+
+7) Github had removed the usercode+password authentication, so "git push"
+   did'n work. So, I changed to SSH::
+     $ git remote -v
+     $ git remote set-url origin git@github.com:koskenni/twol.git

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="twol", # of the PyPI project and package
-    version="0.7.7",
+    version="0.8.0",
     author="Kimmo Koskenniemi",
     author_email="koskenni@gmail.com",
     description="Tools for simplified two-level morphology",
@@ -35,12 +35,14 @@ setuptools.setup(
         ]
     },
     include_package_data=True,
-    python_requires='>=3.6,<3.8',
+    python_requires='>=3.8',
         install_requires=[
             'grapheme',
-            'hfst',
-            ##'hfst==3.15.0.0b0',
-            'TatSu==4.4.0',
+            # 'hfst',
+            #'hfst==3.15.0.0b0',
+            'hfst_dev==3.15.0.10b0',
+            #'TatSu==4.4.0',
+            'TatSu==5.7',
     ]
 
 )

--- a/twol/aligner.py
+++ b/twol/aligner.py
@@ -8,8 +8,10 @@ Copyright 2017-2019, Kimmo Koskenniemi
 This is free software according to GNU GPL 3 license.
 """
 
-import hfst
+import hfst_dev as hfst
+
 import twol.cfg as cfg
+
 import twol.multialign as multialign
 
 def align_two_words(in_word, out_word, aligner_fst, zero, number):

--- a/twol/cfg.py
+++ b/twol/cfg.py
@@ -5,12 +5,9 @@ programs, e.g. `twol`, `multialign`, `table2words`,
 `words2zerofilled` etc.
 """
 
-__author__ = """© Kimmo Koskenniemi, 2018"""
+__author__ = """© Kimmo Koskenniemi, 2018, 2022"""
 
 import re
-import hfst
-
-#hfst.set_default_fst_type(hfst.ImplementationType.FOMA_TYPE)
 
 verbosity = 0
 

--- a/twol/fs.py
+++ b/twol/fs.py
@@ -4,7 +4,7 @@ The HFST engine used for accomplishing the operations but all functions make cop
 
 © Kimmo Koskenniemi, 2018. This is free code under the GPL 3 license."""
 
-import hfst
+import hfst_dev as hfst
 import grapheme
 import twol.cfg as cfg
 
@@ -86,7 +86,7 @@ def symbol_to_fsa(sym):
     The symbol 'sym' may be e.g. a composed Unicode grapheme, i.e. a
     string of two or more Unicode characters.
     """
-    bfsa = hfst.HfstBasicTransducer()
+    bfsa = hfst.HfstIterableTransducer()
     string_pair_path = ((sym, sym))
     bfsa.disjunct(string_pair_path, 0)
     fsa = hfst.fst(bfsa)
@@ -94,7 +94,7 @@ def symbol_to_fsa(sym):
 
 def symbol_pair_to_fst(insym, outsym):
     """"Return a FST which accepts one the pair string 'insym:outsym'"""
-    bfst = hfst.HfstBasicTransducer()
+    bfst = hfst.HfstIterableTransducer()
     string_pair_path = ((insym, outsym))
     bfsa.disjunct(string_pair_path, 0)
     fst = hfst.fst(bfst)
@@ -102,7 +102,7 @@ def symbol_pair_to_fst(insym, outsym):
 
 def string_to_fsa(grapheme_string):
     """Return a FSA which accepts the sequence of graphemes in the string"""
-    bfsa = hfst.HfstBasicTransducer()
+    bfsa = hfst.HfstIterableTransducer()
     grapheme_list = list(grapheme.graphemes(grapheme_string))
     string_pair_path = tuple(zip(grapheme_list, grapheme_list))
     if cfg.verbosity >= 10:

--- a/twol/metric.py
+++ b/twol/metric.py
@@ -11,10 +11,14 @@ This is free software according to GNU GPL 3 license.
 """
 
 import sys
+
 import re
+
 import twol.alphabet as alphabet
+
 import twol.cfg as cfg
-import hfst
+
+import hfst_dev as hfst
 
 within_set_lst = []
 forall_lst = []

--- a/twol/multialign.py
+++ b/twol/multialign.py
@@ -9,11 +9,16 @@ This is free software according to GNU GPL 3 license.
 
 """
 
-import hfst
+import hfst_dev as hfst
+
 import grapheme
+
 import twol.fs as fs
+
 import twol.cfg as cfg
+
 import twol.twbt as twbt
+
 import twol.alphabet as alphabet
 
 
@@ -81,8 +86,8 @@ Returns a transducer where input labels of thrasitions are concatenations of the
 """
     if cfg.verbosity >= 10:
         print("to be accumulated:\n", fst)
-    bfst = hfst.HfstBasicTransducer(fst)
-    result_bfst = hfst.HfstBasicTransducer()
+    bfst = hfst.HfstIterableTransducer(fst)
+    result_bfst = hfst.HfstIterableTransducer()
     for state in bfst.states():
         result_bfst.add_state(state)
         if bfst.is_final_state(state):

--- a/twol/tester.py
+++ b/twol/tester.py
@@ -15,10 +15,15 @@ The formulae::
 
 """
 import os
+
 import re
-import hfst
+
+import hfst_dev as hfst
+
 import twol.cfg as cfg
+
 import twol.twexamp as twexamp
+
 import twol.twbt as twbt
 
 def paths(heading, fst):

--- a/twol/twbt.py
+++ b/twol/twbt.py
@@ -5,7 +5,9 @@ Copyright 2015-2020, Kimmo Koskenniemi
 This program is free software under Gnu GPL 3 or later
 """
 
-import hfst
+import hfst_dev as hfst
+
+import twol.cfg as cfg
 
 def pairname(insym, outsym):
     """Convert a pair of symbols into a single label
@@ -30,7 +32,7 @@ def pairname(insym, outsym):
 def equivpairs(bfst):
     """Find and print all sets of equivalent transition pairs.
 
-    bfst -- a HfstBasicTransducer whose transition symbol pairs are
+    bfst -- a HfstIterableTransducer whose transition symbol pairs are
     analyzed
 
     Sets of transition symbol pairs behaving identicaly are computed.
@@ -66,7 +68,7 @@ def equivpairs(bfst):
 
 def fst2dicfst(FST):
     """Returns a dict which gives the transition dict for each state"""
-    BFST = hfst.HfstBasicTransducer(FST)
+    BFST = hfst.HfstIterableTransducer(FST)
     dicfst = {}
     for state in BFST.states():
         tdir = {}
@@ -79,7 +81,7 @@ def fst2dicfst(FST):
 
 def fst_to_fsa(FST, separator='^'):
     """Converts FST into an FSA by joining input and output symbols with separator"""
-    FB = hfst.HfstBasicTransducer(FST)
+    FB = hfst.HfstIterableTransducer(FST)
     sym_pairs = FB.get_transition_pairs()
     dict = {}
     for sym_pair in sym_pairs:
@@ -93,7 +95,7 @@ def fst_to_fsa(FST, separator='^'):
 
 def fsa_to_fst(FSA, separator='^'):
     """hfst.fsa_to_fst does the same """
-    BFSA = hfst.HfstBasicTransducer(FSA)
+    BFSA = hfst.HfstIterableTransducer(FSA)
     sym_pairs = BFSA.get_transition_pairs()
     dic = {}
     for sym_pair in sym_pairs:
@@ -105,7 +107,7 @@ def fsa_to_fst(FSA, separator='^'):
     return FST
 
 def ppfst(FST, print_equiv_classes=True, title=""):
-    """Pretty-prints a HfstTransducer or a HfstBasicTransducer.
+    """Pretty-prints a HfstTransducer or a HfstIterableTransducer.
 
     FST -- the transducer to be pretty-printed
     print_equiv_classes -- if True, then print also the equivalence classes
@@ -125,7 +127,7 @@ def ppfst(FST, print_equiv_classes=True, title=""):
         print("\n" + title)
     else:
         print("\n" + FST.get_name())
-    BFST = hfst.HfstBasicTransducer(FST)
+    BFST = hfst.HfstIterableTransducer(FST)
     labsy, transy = equivpairs(BFST)
     for state in BFST.states():
         d = {}
@@ -157,7 +159,7 @@ def ppfst(FST, print_equiv_classes=True, title=""):
 
 def ppdef(XRC, name, displayed_formula):
     FST = XRC.compile(name)
-    BFST = hfst.HfstBasicTransducer(FST)
+    BFST = hfst.HfstIterableTransducer(FST)
     FST = hfst.HfstTransducer(BFST)
     FST.set_name(name + " = " + displayed_formula)
     ppfst(FST, True)
@@ -187,7 +189,7 @@ def paths(TR, limit=30):
 
 def expanded_examples(TR, insyms, symbol_pair_set):
     # print("symbol_pair_set =", symbol_pair_set) ##
-    BT = hfst.HfstBasicTransducer(TR)
+    BT = hfst.HfstIterableTransducer(TR)
     # print("BT.get_transition_pairs() =", BT.get_transition_pairs()) ##
     for insym in insyms:
         lst = [(ins, outs)

--- a/twol/twexamp.py
+++ b/twol/twexamp.py
@@ -12,14 +12,14 @@ hfst.rules.restriction
 
 """
 import re
-import hfst
+import hfst_dev as hfst
 import twol.cfg as cfg
 import twol.twbt as twbt
 
 def pairs_to_fst(pair_set):
     """Converts a seq of symbol pairs into a fst that accepts any of them
 """
-    pairs_bfst = hfst.HfstBasicTransducer()
+    pairs_bfst = hfst.HfstIterableTransducer()
     for pair in pair_set:
         pairs_bfst.disjunct((pair,), 0)       # arg in tokenized format
     fst = hfst.HfstTransducer(pairs_bfst)
@@ -62,8 +62,7 @@ def read_examples(filename_lst=["test.pstr"], build_fsts=True):
         if not os.path.isfile(f):
             exit("EXAMPLE FILE {} DOES NOT EXIST".format(f))
     if build_fsts:
-        import hfst
-        examples_bfst = hfst.HfstBasicTransducer()
+        examples_bfst = hfst.HfstIterableTransducer()
     for line_nl in fileinput.input(filename_lst):
         line = line_nl.strip()
         if not line or line.startswith("!"):
@@ -132,7 +131,6 @@ def main():
        $ twol-examp examples.pstr examples.fst
 
     """
-    import hfst
     import argparse
     arpar = argparse.ArgumentParser("python3 twexamp.py")
     arpar.add_argument(

--- a/twol/twolcomp.py
+++ b/twol/twolcomp.py
@@ -5,14 +5,23 @@
 # This orogram is free software according to GPL 3 license
 #
 import sys
+
 import re
+
 import fileinput
-import hfst
+
+import hfst_dev as hfst
+
 import twol.cfg as cfg
+
 import twol.twbt as twbt
+
 import twol.twexamp as twexamp
+
 import twol.twrule as twrule
+
 from twol.twparser import init as twparser_init
+
 from twol.twparser import parse_rule
 
 

--- a/twol/twolcsyntax.ebnf
+++ b/twol/twolcsyntax.ebnf
@@ -24,15 +24,16 @@ output_coercion_rule = left:expression op:'<=' ~ right:contexts ';' ;
 
 input_coercion_rule = left:expression op:'<--' ~ right:contexts ';' ;
 
-contexts = context_lst | context ;
+contexts = lst:context_lst | lst:context ;
 
 context_lst = left:context ',' right:contexts ;
 
 context = left:[expression] '_' right:[expression] ;
 
-expression = composition | term ;
+##expression = composition | term ;
+expression = term ;
 
-composition = left:term '.o.' ~ right:expression ;
+##composition = left:term '.o.' ~ right:expression ;
 
 term = union | difference | intersection | factor ;
 
@@ -49,8 +50,8 @@ concatenation = left:unit right:factor ;
 unit =
     | Kleene_plus
     | Kleene_star
-    | Upper
-    | Lower
+    ##| Upper
+    ##| Lower
     | Morphophonemic
     | Surface
     | One_but_not
@@ -61,9 +62,9 @@ Kleene_plus = expr:atom '+' ;
 
 Kleene_star = expr:atom '*' ;
 
-Upper = expr:atom '.u' ;
+#Upper = expr:atom '.u' ;
 
-Lower = expr:atom '.l' ;
+#Lower = expr:atom '.l' ;
 
 Morphophonemic = expr:atom '.m' ;
 

--- a/twol/twparser.py
+++ b/twol/twparser.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
+
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys, re, json
+
 from codecs import open
+
 from pprint import pprint
 
 import tatsu
@@ -13,11 +16,12 @@ from tatsu.ast import AST
 from tatsu.walkers import NodeWalker
 #from tatsu import walkers
 #from walkers import NodeWalker
-
 from tatsu.exceptions import ParseException, FailedParse, ParseError, FailedSemantics
 
-import hfst
+import hfst_dev as hfst
+
 import twol.cfg as cfg
+
 import twol.twexamp as twexamp
 
 class TwolRegexSemantics(object):
@@ -68,8 +72,8 @@ class TwolRegexSemantics(object):
     def concatenation(self, ast):
         return "[{} {}]".format(ast.left, ast.right)
 
-    def composition(self, ast):
-        return "[{} .o. {}]".format(ast.left, ast.right)
+    #def composition(self, ast):
+    #    return "[{} .o. {}]".format(ast.left, ast.right)
 
     def crossproduct(self, ast):
         return "[{} .x. {}]".format(ast.left, ast.right)
@@ -80,11 +84,11 @@ class TwolRegexSemantics(object):
     def Kleene_plus(self, ast):
         return "[{}]+".format(ast.expr)
 
-    def Upper(self, ast):
-        return "[{}].u".format(ast.expr)
+    #def Upper(self, ast):
+    #    return "[{}].u".format(ast.expr)
 
-    def Lower(self, ast):
-        return "[{}].l".format(ast.expr)
+    #def Lower(self, ast):
+    #    return "[{}].l".format(ast.expr)
 
     def One_but_not(self, ast):
         return r"[PI - [{}]]".format(ast.expr)
@@ -170,6 +174,10 @@ class TwolFstSemantics(object):
         result = ("/<=", ast.left, ast.right)
         return result
 
+    def contexts(self, ast):
+        result = ast.lst.copy()
+        return result
+
     def context_lst(self, ast):
         left_lst = ast.left.copy()
         right_lst = ast.right.copy()
@@ -218,13 +226,13 @@ class TwolFstSemantics(object):
         result_fst.set_name(name)
         return result_fst
 
-    def composition(self, ast):
-        name = "[{} .o. {}]".format(ast.left.get_name(), ast.right.get_name())
-        result_fst = ast.left.copy()
-        result_fst.compose(ast.right)
-        result_fst.minimize()
-        result_fst.set_name(name)
-        return result_fst
+    #def composition(self, ast):
+    #    name = "[{} .o. {}]".format(ast.left.get_name(), ast.right.get_name())
+    #    result_fst = ast.left.copy()
+    #    result_fst.compose(ast.right)
+    #    result_fst.minimize()
+    #    result_fst.set_name(name)
+    #    return result_fst
 
     def crossproduct(self, ast):
         name = "[{} .x. {}]".format(ast.left.get_name(), ast.right.get_name())
@@ -249,32 +257,32 @@ class TwolFstSemantics(object):
         result_fst.set_name(name)
         return result_fst
 
-    def Upper(self, ast):
-        """Input projection
+    #def Upper(self, ast):
+    #    """Input projection
 
-        Note that the result is outside the Pi*, i.e. not a valid
-        two-level expression.  This operator should be avoided at all
-        costs.
-        """
-        name = "[{}].u".format(ast.expr.get_name())
-        result_fst = ast.expr.copy()
-        result_fst.input_project()
-        result_fst.set_name(name)
-        return result_fst
+    #    Note that the result is outside the Pi*, i.e. not a valid
+    #    two-level expression.  This operator should be avoided at all
+    #    costs.
+    #    """
+    #    name = "[{}].u".format(ast.expr.get_name())
+    #    result_fst = ast.expr.copy()
+    #    result_fst.input_project()
+    #    result_fst.set_name(name)
+    #    return result_fst
 
-    def Lower(self, ast):
-        """Output projection
+    #def Lower(self, ast):
+    #    """Output projection
 
-        Note that the result is outside the Pi*, i.e. not a valid
-        two-level expression.  This operator should be avoided at all
-        costs.
-        """
-        name = "[{}].l".format(ast.expr.get_name())
-        result_fst = ast.expr.copy()
-        result_fst.output_project()
-        result_fst.minimize()
-        result_fst.set_name(name)
-        return result_fst
+    #    Note that the result is outside the Pi*, i.e. not a valid
+    #    two-level expression.  This operator should be avoided at all
+    #    costs.
+    #    """
+    #    name = "[{}].l".format(ast.expr.get_name())
+    #    result_fst = ast.expr.copy()
+    #    result_fst.output_project()
+    #    result_fst.minimize()
+    #    result_fst.set_name(name)
+    #    return result_fst
 
     def Morphophonemic(self, ast):
         """Surface completion
@@ -467,11 +475,11 @@ def parse_rule(parser, line_nl, line_no, line_lst, start="expr_start"):
         return "?", None, None
 
 def main():
-    import hfst
+    #import hfst
     import argparse
     import twol.twbt as twbt
-    import twol.cfg as cfg
-    import twol.twexamp as twexamp
+    #import twol.cfg as cfg
+    #import twol.twexamp as twexamp
     arpar = argparse.ArgumentParser(
         description="A compiler and tester for two-level rules")
     arpar.add_argument("start",

--- a/twol/twrule.py
+++ b/twol/twrule.py
@@ -2,11 +2,17 @@
 """
 __author__ = "© Kimmo Koskenniemi, 2018 - 2020"
 __version__ = "2020-02-01"
+
 import re
-import hfst
+
+import hfst_dev as hfst
+
 import twol.cfg as cfg
+
 import twol.fs as fs
+
 import twol.twbt as twbt
+
 import twol.twexamp as twexamp
 
 def init():


### PR DESCRIPTION
Ghanges that make TWOL compatible with Python 3.9 and TatSu 5.7. Automatic PyPI installation of the relevant hfst-dev does not necessarily work yet.